### PR TITLE
Use the empty base class optimisation to reduce space requirements to the same as a std::unique_ptr when the copier has no data members

### DIFF
--- a/indirect.h
+++ b/indirect.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <utility>
+#include <type_traits>
 
 namespace jbcoe {
 
@@ -11,10 +12,29 @@ struct default_copy {
   T* operator()(const T& t) const { return new T(t); }
 };
 
-template <class T, class C = default_copy<T>, class D = std::default_delete<T>>
-class indirect {
-  std::unique_ptr<T, D> ptr_;
+template <class T, class C = default_copy<T>, bool CanBeEmptyBaseClass = std::is_empty_v<C> && !std::is_final_v<C> >
+class indirect_base {
+protected:
+  indirect_base() noexcept(noexcept(C())) = default;
+  indirect_base(C c) : c_(std::move(c)) {}
+  const C& get() const noexcept { return c_; }
   C c_;
+};
+
+template <class T, class C>
+class indirect_base<T, C, true> : private C {
+protected:
+  indirect_base() noexcept(noexcept(C())) = default;
+  indirect_base(C c) : C(std::move(c)) {}
+  const C& get() const noexcept { return *this; }
+};
+
+template <class T, class C = default_copy<T>, class D = std::default_delete<T>>
+class indirect : private indirect_base<T, C> {
+  
+  using base = indirect_base<T, C>;
+  
+  std::unique_ptr<T, D> ptr_;
 
  public:
   indirect() = default;
@@ -24,24 +44,24 @@ class indirect {
     ptr_ = std::unique_ptr<T, D>(new T(std::forward<Ts>(ts)...), D{});
   }
 
-  indirect(T* t, C c = C{}, D d = D{}) : c_(std::move(c)) {
+  indirect(T* t, C c = C{}, D d = D{}) : base(std::move(c)) {
     ptr_ = std::unique_ptr<T, D>(t, std::move(d));
   }
 
-  indirect(const indirect& i) {
+  indirect(const indirect& i) : base(get_c()) {
     if (i.ptr_) { 
-      ptr_ = std::unique_ptr<T, D>(i.c_(*i.ptr_), D{});
+      ptr_ = std::unique_ptr<T, D>(get_c()(*i.ptr_), D{});
     }
   }
 
-  indirect(indirect&& i) : c_(std::move(i.c_)) {
+  indirect(indirect&& i) : base(std::move(i)) {
     ptr_ = std::move(i.ptr_);
   }
 
   indirect& operator = (const indirect& i) {
     if (i.ptr_) { 
       if (!ptr_){
-        ptr_ = std::unique_ptr<T, D>(i.c_(*i.ptr_), D{});
+        ptr_ = std::unique_ptr<T, D>(get_c()(*i.ptr_), D{});
       }
       else{
         *ptr_ = *i.ptr_;
@@ -51,7 +71,7 @@ class indirect {
   }
 
   indirect& operator = (indirect&& i) {
-    c_ = std::exchange(i.c_, C{});
+    base::operator=(std::move(i));
     ptr_ = std::exchange(i.ptr_, nullptr);
     return *this;
   }
@@ -71,6 +91,9 @@ class indirect {
     swap(lhs.ptr_, rhs.ptr_);
     swap(lhs.c_, rhs.c_);
   }
+
+  private:
+    const C& get_c() const noexcept { return base::get(); }
 };
 
 }  // namespace jbcoe

--- a/test_indirect.cpp
+++ b/test_indirect.cpp
@@ -4,11 +4,29 @@
 
 using jbcoe::indirect;
 
-TEST_CASE("Nothing to see here", "[dummy]") { REQUIRE(2 + 2 != 5); }
+/*! Helper function to capture constexpr results in catch test reporting.
+    \note
+        Credit to Jason Turner: https://twitter.com/lefticus/status/980530307580514304
+    \tparam B
+        Compile time condition.
+    \return
+        The compile time condition result.
+ */
+template<bool B>
+bool static_test()
+{
+    static_assert(B);
+    return B;
+}
 
-TEST_CASE("Defeault construction for indirect", "[constructor.default]")
+TEST_CASE("Ensure that indirect uses the minum space requirements", "[indirect.sizeof]")
+{
+    REQUIRE(static_test<sizeof(indirect<int>) == sizeof(std::unique_ptr<int>)>);
+}
+
+TEST_CASE("Default construction for indirect", "[constructor.default]")
 {   
-   indirect<int> a{};
+    indirect<int> a{};
     REQUIRE(a.operator->() == nullptr); 
 }
 

--- a/test_indirect.cpp
+++ b/test_indirect.cpp
@@ -22,7 +22,7 @@ bool static_test()
 
 TEST_CASE("Ensure that indirect uses the minum space requirements", "[indirect.sizeof]")
 {
-    REQUIRE(static_test<sizeof(indirect<int>) == sizeof(std::unique_ptr<int>)>);
+    REQUIRE(static_test<sizeof(indirect<int>) == sizeof(std::unique_ptr<int>)>());
 }
 
 TEST_CASE("Default construction for indirect", "[constructor.default]")


### PR DESCRIPTION
This change uses the same technique used by the Clang STL to reduce the std::unique_ptr memory footprint to that of a just a pointer when the deleter object is empty.  In the C++ 20 world this can be simplified by the [[no_unique_address] attribute](https://en.cppreference.com/w/cpp/language/attributes/no_unique_address)